### PR TITLE
Fix pydantic serializer warnings (#31)

### DIFF
--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Union
 
 from pydantic import Field
 from pydantic.v1.fields import Undefined
@@ -26,7 +26,7 @@ BASE_DIR = CUR_DIR.parent
 
 class DatabaseSettings(BaseDBConfig):
     # https://docs.djangoproject.com/en/3.1/ref/settings/#databases
-    default: str = Field(
+    default: Union[str, Dict] = Field(
         default=str(f"sqlite:///{BASE_DIR}/db.sqlite3"),
         validation_alias="DATABASE_URL",
         conn_max_age=0,

--- a/tests/test_db_config.py
+++ b/tests/test_db_config.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from pydantic import Field, PostgresDsn
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -9,7 +9,7 @@ from pydjantic import BaseDBConfig
 
 def test_empty():
     class DatabaseConfig(BaseDBConfig):
-        default: Optional[PostgresDsn] = None
+        default: Union[Optional[PostgresDsn], Dict] = None
         replica: Optional[Dict] = None
 
     db_settings = DatabaseConfig()
@@ -97,7 +97,7 @@ def test_exact():
 
 def test_dsn_and_exact_config():
     class DatabaseConfig(BaseDBConfig):
-        default: str = Field(default="postgres://user:password@hostname:5432/dbname")
+        default: Union[str, Dict] = Field(default="postgres://user:password@hostname:5432/dbname")
         replica: PostgresDB = PostgresDB()
 
     db_settings = DatabaseConfig()

--- a/tests/test_to_django.py
+++ b/tests/test_to_django.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 from deepdiff import DeepDiff
 from pydantic import Field, PostgresDsn, SecretStr, ValidationInfo, computed_field, field_validator
@@ -9,7 +9,7 @@ from pydjantic import BaseDBConfig, to_django
 
 def test_to_django_settings():
     class DatabaseConfig(BaseDBConfig):
-        default: PostgresDsn = Field(
+        default: Union[PostgresDsn, Dict] = Field(
             default="postgres://user:password@hostname:5432/dbname",
             validation_alias="DATABASE_URL",
         )


### PR DESCRIPTION
closes #31 

Hi there 👋🏻

As discussed, here is the fix for the warnings.
Please note that I have changed the solution slightly: It now uses `Union` instead of `|`. This ensures backward compatibility with Python 3.8, which this project supports, as `|` was added with 3.10, as far as I know.

Have a nice weekend!